### PR TITLE
Add guess purpose prompts to files

### DIFF
--- a/PG-13/algebra1_problems.py
+++ b/PG-13/algebra1_problems.py
@@ -1,6 +1,9 @@
 import random
 from sympy import symbols, Eq, solve
 
+def guess_purpose():
+    print("Can you guess the purpose of the functions in this file?")
+
 def generate_linear_equation():
     # Generate random coefficients for the linear equation
     x = symbols('x')
@@ -78,3 +81,5 @@ print("Algebra 1 Question:")
 print(question)
 print("Answer:")
 print(answer)
+
+guess_purpose()

--- a/PG-13/boolean_algebra.py
+++ b/PG-13/boolean_algebra.py
@@ -1,4 +1,9 @@
+def guess_purpose():
+    print("Can you guess the purpose of the boolean expression?")
+
 from pyeda.inter import exprvars, And, Or, Not
 A, B, C = exprvars('A B C')
 expression = And(A, Or(Not(B), C))
 print(expression.satisfy_all())
+
+guess_purpose()

--- a/PG-13/linear_algebra.py
+++ b/PG-13/linear_algebra.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+def guess_purpose():
+    print("Can you guess the purpose of the matrix puzzle?")
+
 def generate_matrix_puzzle():
     # Create a random 2x2 matrix
     matrix = np.random.randint(1, 10, (2, 2))
@@ -18,3 +21,4 @@ def generate_matrix_puzzle():
     print(f"Answer: {answer}")
 
 generate_matrix_puzzle()
+guess_purpose()

--- a/computer_literacy.py
+++ b/computer_literacy.py
@@ -1,3 +1,6 @@
+def guess_purpose():
+    print("Can you guess the purpose of the functions in this file?")
+
 def add_binary(bin1, bin2):
     # Convert binary strings to integers, add them, and convert back to binary
     result = bin(int(bin1, 2) + int(bin2, 2))
@@ -62,3 +65,5 @@ print(f"Hexadecimal {hex1} to binary: {hex_to_bin(hex1)}")
 print(f"Bitwise AND of {bin1} and {bin2}: {bitwise_and(bin1, bin2)}")
 print(f"Bitwise OR of {bin1} and {bin2}: {bitwise_or(bin1, bin2)}")
 print(f"Bitwise XOR of {bin1} and {bin2}: {bitwise_xor(bin1, bin2)}")
+
+guess_purpose()

--- a/epsilion-delta.md
+++ b/epsilion-delta.md
@@ -1,3 +1,7 @@
+# Guess the Purpose
+
+Before diving into the details, can you guess the purpose of the epsilon-delta definition of a limit?
+
 In mathematical analysis, the \(\epsilon\)-\(\delta\) definition of a limit is used to formally define the limit of a function at a point. Specifically, the definition states:
 
 Let \( f(x) \) be a function defined on an open interval containing \( c \) (except possibly at \( c \) itself). We say that the limit of \( f(x) \) as \( x \) approaches \( c \) is \( L \), and we write


### PR DESCRIPTION
Add prompts for users to guess the purpose of functions and sections in various files.

* Add `guess_purpose` function in `computer_literacy.py` to prompt users to guess the purpose of the functions in the file and call it at the end of the file.
* Add a section at the beginning of `epsilion-delta.md` asking readers to guess the purpose of the epsilon-delta definition before explaining it.
* Add `guess_purpose` function in `PG-13/algebra1_problems.py` to prompt users to guess the purpose of the functions in the file and call it at the end of the file.
* Add `guess_purpose` function in `PG-13/boolean_algebra.py` to prompt users to guess the purpose of the boolean expression and call it at the end of the file.
* Add `guess_purpose` function in `PG-13/linear_algebra.py` to prompt users to guess the purpose of the matrix puzzle and call it at the end of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ewdlop/Study-Bank.md/pull/1?shareId=9f5eb7ed-d9fc-4dd2-b19f-bcda90d2bbb5).